### PR TITLE
Add fallback Octokit handling for agent events routes

### DIFF
--- a/__tests__/api/agent-events/public-access.test.ts
+++ b/__tests__/api/agent-events/public-access.test.ts
@@ -1,0 +1,116 @@
+import { NextRequest } from 'next/server';
+
+jest.mock('@a24z/observability-sdk', () => ({
+  TursoObservabilitySDK: {
+    createCloud: jest.fn(),
+  },
+}));
+
+jest.mock('@octokit/rest', () => {
+  return {
+    Octokit: jest.fn(),
+  };
+});
+
+jest.mock('@/lib/repo-visibility-cache', () => ({
+  repoVisibilityCache: {
+    get: jest.fn(),
+    set: jest.fn(),
+    has: jest.fn(),
+    clear: jest.fn(),
+    cleanup: jest.fn(),
+    stats: jest.fn(),
+  },
+}));
+
+const { TursoObservabilitySDK } = require('@a24z/observability-sdk');
+const { Octokit } = require('@octokit/rest');
+
+describe('agent-events routes public access fallback', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    process.env.TURSO_DATABASE_URL = 'https://example-db';
+    process.env.TURSO_AUTH_TOKEN = 'test-token';
+    process.env.GITHUB_TOKEN = 'server-token';
+  });
+
+  it('returns repositories when fallback access succeeds after credential error', async () => {
+    const execute = jest.fn().mockResolvedValue({
+      rows: [
+        {
+          repoName: 'demo-repo',
+          repoOwner: 'acme',
+          lastActivity: 1700000000,
+          sessionCount: 3,
+        },
+      ],
+    });
+    const close = jest.fn().mockResolvedValue(undefined);
+    (TursoObservabilitySDK.createCloud as jest.Mock).mockReturnValueOnce({ execute, close });
+
+    const primaryGet = jest.fn().mockRejectedValueOnce({ status: 401, message: 'Bad credentials' });
+    const fallbackGet = jest.fn().mockResolvedValue({});
+    (Octokit as jest.Mock)
+      .mockImplementationOnce(() => ({ repos: { get: primaryGet } }))
+      .mockImplementationOnce(() => ({ repos: { get: fallbackGet } }));
+
+    const { GET } = await import('@/app/api/agent-events/repositories-by-activity/route');
+
+    const request = new Request('http://localhost/api/agent-events/repositories-by-activity', {
+      headers: {
+        authorization: 'Bearer bad-token',
+      },
+    });
+
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.repositories).toHaveLength(1);
+    expect(body.repositories[0]).toMatchObject({ repoName: 'demo-repo', repoOwner: 'acme' });
+    expect(primaryGet).toHaveBeenCalledWith({ owner: 'acme', repo: 'demo-repo' });
+    expect(fallbackGet).toHaveBeenCalledWith({ owner: 'acme', repo: 'demo-repo' });
+    expect(close).toHaveBeenCalled();
+  });
+
+  it('returns timeline events when fallback access succeeds after credential error', async () => {
+    const execute = jest.fn().mockResolvedValue({
+      rows: [
+        {
+          timestamp: 1700000000,
+          event_type: 'agent',
+          tool_name: 'test-tool',
+          session_id: 'session-123',
+          repo_name: 'demo-repo',
+          repo_owner: 'acme',
+        },
+      ],
+    });
+    const close = jest.fn().mockResolvedValue(undefined);
+    (TursoObservabilitySDK.createCloud as jest.Mock).mockReturnValueOnce({ execute, close });
+
+    const primaryGet = jest.fn().mockRejectedValueOnce({ status: 403, message: 'Requires authentication' });
+    const fallbackGet = jest.fn().mockResolvedValue({});
+    (Octokit as jest.Mock)
+      .mockImplementationOnce(() => ({ repos: { get: primaryGet } }))
+      .mockImplementationOnce(() => ({ repos: { get: fallbackGet } }));
+
+    const { GET } = await import('@/app/api/agent-events/timeline/route');
+
+    const request = new NextRequest('http://localhost/api/agent-events/timeline?hours=24', {
+      headers: new Headers({
+        authorization: 'Bearer bad-token',
+      }),
+    });
+
+    const response = await GET(request);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.events).toHaveLength(1);
+    expect(body.events[0]).toMatchObject({ repoName: 'demo-repo', repoOwner: 'acme' });
+    expect(primaryGet).toHaveBeenCalledWith({ owner: 'acme', repo: 'demo-repo' });
+    expect(fallbackGet).toHaveBeenCalledWith({ owner: 'acme', repo: 'demo-repo' });
+    expect(close).toHaveBeenCalled();
+  });
+});

--- a/src/app/api/agent-events/github-access.ts
+++ b/src/app/api/agent-events/github-access.ts
@@ -1,0 +1,72 @@
+import { Octokit } from '@octokit/rest';
+
+export type OctokitLike = Pick<InstanceType<typeof Octokit>, 'repos'>;
+
+export function createFallbackOctokit(userToken: string | null): OctokitLike {
+  const serverToken = process.env.GITHUB_TOKEN;
+
+  if (serverToken && userToken && userToken !== serverToken) {
+    return new Octokit({ auth: serverToken });
+  }
+
+  return new Octokit();
+}
+
+function isCredentialError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const status = (error as { status?: number }).status;
+  const message = String((error as { message?: string }).message || '').toLowerCase();
+
+  if (status !== 401 && status !== 403) {
+    return false;
+  }
+
+  return message.includes('bad credentials') || message.includes('requires authentication');
+}
+
+function isAccessDenied(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const status = (error as { status?: number }).status;
+  return status === 403 || status === 404;
+}
+
+export async function ensureRepoAccessible(
+  primaryOctokit: OctokitLike,
+  fallbackOctokit: OctokitLike,
+  owner?: string,
+  repo?: string
+): Promise<boolean> {
+  if (!owner || !repo) {
+    return false;
+  }
+
+  try {
+    await primaryOctokit.repos.get({ owner, repo });
+    return true;
+  } catch (error) {
+    if (!isCredentialError(error)) {
+      if (isAccessDenied(error)) {
+        return false;
+      }
+
+      throw error;
+    }
+
+    try {
+      await fallbackOctokit.repos.get({ owner, repo });
+      return true;
+    } catch (fallbackError) {
+      if (isAccessDenied(fallbackError)) {
+        return false;
+      }
+
+      throw fallbackError;
+    }
+  }
+}

--- a/src/app/api/agent-events/repositories-by-activity/route.ts
+++ b/src/app/api/agent-events/repositories-by-activity/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { TursoObservabilitySDK } from '@a24z/observability-sdk';
 import { Octokit } from '@octokit/rest';
+import { createFallbackOctokit, ensureRepoAccessible } from '../github-access';
 
 export const dynamic = 'force-dynamic';
 
@@ -74,20 +75,22 @@ export async function GET(request: Request) {
       auth: githubToken || process.env.GITHUB_TOKEN
     });
 
+    const fallbackOctokit = createFallbackOctokit(githubToken);
+
     const accessibleRepositories = await Promise.all(
       repositories.map(async (repo) => {
         try {
-          // Try to fetch the repo with the user's token
-          // If successful, they have access; if 404/403, they don't
-          await octokit.repos.get({
-            owner: repo.repoOwner,
-            repo: repo.repoName
-          });
+          const hasAccess = await ensureRepoAccessible(
+            octokit,
+            fallbackOctokit,
+            repo.repoOwner,
+            repo.repoName
+          );
 
-          // User has access to this repo
-          return repo;
+          return hasAccess ? repo : null;
         } catch (error) {
-          // If user doesn't have access or repo doesn't exist, exclude it
+          // If an unexpected error occurs, exclude the repo but log the issue
+          console.error('[API] Unexpected error checking repo access:', error);
           return null;
         }
       })

--- a/src/app/api/agent-events/timeline/route.ts
+++ b/src/app/api/agent-events/timeline/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { TursoObservabilitySDK } from '@a24z/observability-sdk';
 import { Octokit } from '@octokit/rest';
 import { repoVisibilityCache } from '@/lib/repo-visibility-cache';
+import { createFallbackOctokit, ensureRepoAccessible } from '../github-access';
 
 export const dynamic = 'force-dynamic';
 
@@ -84,6 +85,8 @@ export async function GET(request: NextRequest) {
       auth: githubToken || process.env.GITHUB_TOKEN
     });
 
+    const fallbackOctokit = createFallbackOctokit(githubToken);
+
     const uniqueRepos = new Map<string, { owner: string; name: string }>();
     events.forEach(event => {
       if (event.repoOwner && event.repoName) {
@@ -103,10 +106,16 @@ export async function GET(request: NextRequest) {
         // Try to fetch the repo with the user's token
         // If successful, they have access; if 404/403, they don't
         try {
-          await octokit.repos.get({ owner, repo: name });
-          accessibleRepos.set(key, true);
+          const hasAccess = await ensureRepoAccessible(
+            octokit,
+            fallbackOctokit,
+            owner,
+            name
+          );
+
+          accessibleRepos.set(key, hasAccess);
         } catch (error: any) {
-          // If user doesn't have access or repo doesn't exist, exclude it
+          console.error('[API] Unexpected error checking repo access:', error);
           accessibleRepos.set(key, false);
         }
       })


### PR DESCRIPTION
## Summary
- add a shared helper that retries repository lookups with a fallback Octokit client when credential errors occur
- update the repositories-by-activity and timeline routes to keep public repositories visible even if the user token is invalid
- add tests covering the fallback behaviour for public repositories and timeline events

## Testing
- npx jest __tests__/api/agent-events/public-access.test.ts *(fails in this environment: npm registry access forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68f642c6ce60832185a72ca83e2c855f